### PR TITLE
feat: make Intel Wireless-AC 9560 support wi-fi

### DIFF
--- a/DELL-G7-7588/EFI-OC084/OC/Kexts/AirportItlwm.kext/Contents/Info.plist
+++ b/DELL-G7-7588/EFI-OC084/OC/Kexts/AirportItlwm.kext/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>BuildMachineOSBuild</key>
-	<string>19G73</string>
+	<string>19H15</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -17,27 +17,29 @@
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>MacOSX</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1.2.0</string>
 	<key>DTCompiler</key>
 	<string>com.apple.compilers.llvm.clang.1_0</string>
 	<key>DTPlatformBuild</key>
-	<string>11E708</string>
+	<string>12B45b</string>
+	<key>DTPlatformName</key>
+	<string>macosx</string>
 	<key>DTPlatformVersion</key>
-	<string>GM</string>
+	<string>11.0</string>
 	<key>DTSDKBuild</key>
-	<string>16C58</string>
+	<string>20A2408</string>
 	<key>DTSDKName</key>
-	<string>macosx10.12</string>
+	<string>macosx11.0</string>
 	<key>DTXcode</key>
-	<string>1160</string>
+	<string>1220</string>
 	<key>DTXcodeBuild</key>
-	<string>11E708</string>
+	<string>12B45b</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>itlwm</key>
@@ -48,43 +50,12 @@
 			<string>AirportItlwm</string>
 			<key>IOMatchCategory</key>
 			<string>IODefaultMatchCategory</string>
-			<key>IOPCIPrimaryMatch</key>
-			<string>0x00008086&amp;0x0000ffff</string>
+			<key>IOPCIMatch</key>
+			<string>0x27238086 0x43F08086 0xA0F08086 0x34F08086 0x4DF08086 0x02F08086 0x3DF08086 0x06F08086 0x27208086 0x08b18086 0x08b28086 0x08b38086 0x08b48086 0x095a8086 0x095b8086 0x31658086 0x31668086 0x24f38086 0x24f48086 0x24f58086 0x24f68086 0x24fb8086 0x24fd8086 0x25268086 0x9df08086 0xa3708086 0x31DC8086 0x30DC8086 0x271C8086 0x271B8086 0x42a48086 0x00a08086 0x00a48086 0x02a08086 0x40a48086 0x00608086 0x00648086 0x02608086 0x02648086 0x42298086 0x422b8086 0x422c8086 0x42308086 0x42328086 0x42358086 0x42368086 0x42378086 0x42388086 0x42398086 0x423a8086 0x423b8086 0x423c8086 0x423d8086 0x00828086 0x00838086 0x00848086 0x00858086 0x00878086 0x00898086 0x008a8086 0x008b8086 0x00908086 0x00918086 0x08928086 0x08938086 0x08948086 0x08958086 0x08968086 0x08978086 0x08ae8086 0x08af8086 0x088e8086 0x088f8086 0x08908086 0x08918086 0x08878086 0x08888086</string>
 			<key>IOProbeScore</key>
 			<integer>2000</integer>
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
-			<key>WiFiConfig</key>
-			<dict>
-				<key>WiFi_1</key>
-				<dict>
-					<key>password</key>
-					<string>zxyssdt112233</string>
-					<key>ssid</key>
-					<string>ssdt</string>
-				</dict>
-				<key>WiFi_2</key>
-				<dict>
-					<key>password</key>
-					<string>zxyssdt112233</string>
-					<key>ssid</key>
-					<string>ssdt_5G</string>
-				</dict>
-				<key>WiFi_3</key>
-				<dict>
-					<key>password</key>
-					<string></string>
-					<key>ssid</key>
-					<string>Redmi</string>
-				</dict>
-				<key>WiFi_4</key>
-				<dict>
-					<key>password</key>
-					<string>9utc5c5f</string>
-					<key>ssid</key>
-					<string>CMCC-KtG6</string>
-				</dict>
-			</dict>
 		</dict>
 	</dict>
 	<key>LSMinimumSystemVersion</key>
@@ -108,5 +79,7 @@
 		<key>com.apple.kpi.mach</key>
 		<string>16.7</string>
 	</dict>
+	<key>OSBundleRequired</key>
+	<string>Network-Root</string>
 </dict>
 </plist>


### PR DESCRIPTION
Make `Intel Wireless-AC 9560` support wi-fi on `Catalina 10.15.7`, just replaced AirportItlwm.kext. Wi-Fi and bluetooth work well for me.
![](https://i.loli.net/2020/12/06/AvxGDLkeiZ1EosY.png)

### References
Supported Intel WI-FI Cards By itlwm:
- 3xxx: 3160, 3165, 3168
- 7xxx: 7260, 7265
- 9xxx：9260,9461, 9462, 9560
- 22000：ax200
- [Supported Devices List](https://openintelwireless.github.io/itlwm/Compat.html)

AirportItlwm.kext download from  https://github.com/1hbb/OpenIntelWireless-Factory/releases, support OS:
- AirportItlwm-BigSur
- AirportItlwm-Catalina
- AirportItlwm-HighSierra
- AirportItlwm-Mojave

### Projects
- [OpenIntelWireless-Factory](https://github.com/1hbb/OpenIntelWireless-Factory)

Both itlwm.kext and AirportItlwm.kext work for Intel WI-FI card.
Learn more from [OpenIntelWireless](https://github.com/OpenIntelWireless) docs: https://openintelwireless.github.io/itlwm/Installation.html.



